### PR TITLE
修复对JS的处理

### DIFF
--- a/internal/unpack/ujs.go
+++ b/internal/unpack/ujs.go
@@ -54,7 +54,7 @@ func cleanDefineFunc(jsCode string) string {
 // extractDefineParams 提取所有 define 函数的第一个和第二个参数
 func extractDefineParams(jsCode string) ([]DefineParams, error) {
 	// 正则表达式提取 define 函数的第一个和第二个参数
-	re := regexp.MustCompile(`define\s*\(\s*["']([^"']+)["']\s*,\s*function\s*\(([^)]*)\)\s*\{([\s\S]*?)\}\s*,\s*\{[^}]*isPage\s*:\s*[^}]*\}\s*\)\s*;`)
+	re := regexp.MustCompile(`define\s*\(\s*["']([^"']+)["']\s*,\s*function\s*\(([^)]*)\)\{\s*\n[^\n]+\n`)
 	matches := re.FindAllStringSubmatch(jsCode, -1)
 
 	if len(matches) == 0 {


### PR DESCRIPTION
这个PR只改动了ujs.go文件中extractDefineParams函数对JS代码的正则表达式。

 原来的表达式会对`isPage`字符串进行检测，但实际上部分小程序JS代码中并不包含该字符串，例如[问题#63](https://github.com/Ackites/KillWxapkg/issues/63)中的截图。
```
define\s*\(\s*["']([^"']+)["']\s*,\s*function\s*\(([^)]*)\)\s*\{([\s\S]*?)\}\s*,\s*\{[^}]*isPage\s*:\s*[^}]*\}\s*\)\s*;
```

改动之后的正则表达式直接匹配`define`和`function`的下一行的所有内容。
```
define\s*\(\s*["']([^"']+)["']\s*,\s*function\s*\(([^)]*)\)\{\s*\n[^\n]+\n`
```